### PR TITLE
Find translations with keys that contain escaped characters

### DIFF
--- a/src/main/com/fulcrologic/fulcro_i18n/gettext.clj
+++ b/src/main/com/fulcrologic/fulcro_i18n/gettext.clj
@@ -35,12 +35,13 @@
   [gettext-block]
   (let [lines (str/split-lines gettext-block)]
     (-> (reduce (fn [{:keys [msgid msgctxt msgstr section] :as acc} line]
-                  (let [[_ k v :as keyline] (re-matches #"^(msgid|msgctxt|msgstr)\s+\"(.*)\"\s*$" line)]
+                  (let [[_ k v :as keyline] (re-matches #"^(msgid|msgctxt|msgstr)\s+\"(.*)\"\s*$" line)
+                        unescaped-value (when v (str/replace v #"\\" ""))]
                     (cond
                       (and line (.matches line "^\".*\"$")) (update acc section #(str % (stripquotes line)))
                       (and k (#{"msgid" "msgctxt" "msgstr"} k)) (-> acc
                                                                   (assoc :section (keyword k))
-                                                                  (update (keyword k) #(str % v)))
+                                                                  (update (keyword k) #(str % unescaped-value)))
                       :else (do
                               (println "Unexpected input -->" line "<--")
                               acc)))) {} lines)

--- a/src/test/com/fulcrologic/fulcro_i18n/i18n_spec.cljc
+++ b/src/test/com/fulcrologic/fulcro_i18n/i18n_spec.cljc
@@ -160,6 +160,7 @@
                        ::i18n/translations {["" "It is {n,date}"]       "Es {n, date}"
                                             ["" "Hello, {name}"]        "Hola {name}"
                                             ["Gender abbreviation" "M"] "M"
+                                            ["" "\"This\" is quoted"] "\"Esto\" se cita"
                                             ["" "Hello"]                "Hola"}})))))
 
 #?(:clj

--- a/src/test/fulcro/es.po
+++ b/src/test/fulcro/es.po
@@ -34,3 +34,7 @@ msgstr "M"
 #: i18n_alpha_cards.js:206
 msgid "Hello"
 msgstr "Hola"
+
+#: i18n_alpha_cards.js:206
+msgid "\"This\" is quoted"
+msgstr "\"Esto\" se cita"


### PR DESCRIPTION
We have multiple translations in our app that look like this:

`(tr "Hi, \"This\" is quoted")`

Using `gettext` will make this string appear like this in our translations file:
```
msgid "Hi, \"This\" is quoted"
```

The translation can not be found with the key `"Hi, \"This\" is quoted"` because the map of translations that fulcro-i18n generates currently looks like this:

```
{["" "Hi, \\\"This\\\" is quoted"] "{translation}"}
```

instead of

```
{["" "Hi, \"This\" is quoted"] "{translation}"}
```

Therefore `(tr "Hi, \"This\" is quoted")` will not be translated and will default into `Hi, "This" is quoted`